### PR TITLE
Reduced autofac version to 3.5.2

### DIFF
--- a/sample/MyCalculator/MyCalculator.REPL/MyCalculator.REPL.csproj
+++ b/sample/MyCalculator/MyCalculator.REPL/MyCalculator.REPL.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.0.0\lib\net451\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/sample/MyCalculator/MyCalculator.REPL/packages.config
+++ b/sample/MyCalculator/MyCalculator.REPL/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.0.0" targetFramework="net452" />
+  <package id="Autofac" version="3.5.2" targetFramework="net452" />
 </packages>

--- a/sample/MyCalculator/MyCalculator.Specs/MyCalculator.Specs.csproj
+++ b/sample/MyCalculator/MyCalculator.Specs/MyCalculator.Specs.csproj
@@ -35,13 +35,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.0.0\lib\net451\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SpecFlow.Autofac.SpecFlowPlugin, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SpecFlow.Autofac.1.0.1\lib\net45\SpecFlow.Autofac.SpecFlowPlugin.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\src\SpecFlow.Autofac.SpecFlowPlugin\bin\Debug\SpecFlow.Autofac.SpecFlowPlugin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/sample/MyCalculator/MyCalculator.Specs/packages.config
+++ b/sample/MyCalculator/MyCalculator.Specs/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.0.0" targetFramework="net452" />
+  <package id="Autofac" version="3.5.2" targetFramework="net452" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net452" />
-  <package id="SpecFlow.Autofac" version="1.0.1" targetFramework="net452" />
   <package id="SpecFlow.MsTest" version="2.1.0" targetFramework="net452" />
 </packages>

--- a/sample/MyCalculator/MyCalculator/MyCalculator.csproj
+++ b/sample/MyCalculator/MyCalculator/MyCalculator.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.0.0\lib\net451\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/sample/MyCalculator/MyCalculator/packages.config
+++ b/sample/MyCalculator/MyCalculator/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.0.0" targetFramework="net452" />
+  <package id="Autofac" version="3.5.2" targetFramework="net452" />
 </packages>

--- a/src/NuGetPackages/SpecFlow.Autofac/SpecFlow.Autofac.nuspec
+++ b/src/NuGetPackages/SpecFlow.Autofac/SpecFlow.Autofac.nuspec
@@ -17,7 +17,7 @@
     <tags>specflow autofac di dependency injection</tags>
     <dependencies>
       <dependency id="SpecFlow" version="2.1.0" />
-      <dependency id="Autofac" version="4.0.0" />
+      <dependency id="Autofac" version="3.5.2" />
     </dependencies>
   </metadata>
 </package>

--- a/src/SpecFlow.Autofac.SpecFlowPlugin/SpecFlow.Autofac.SpecFlowPlugin.csproj
+++ b/src/SpecFlow.Autofac.SpecFlowPlugin/SpecFlow.Autofac.SpecFlowPlugin.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.0.0\lib\netstandard1.1\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SpecFlow.Autofac.SpecFlowPlugin/packages.config
+++ b/src/SpecFlow.Autofac.SpecFlowPlugin/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.0.0" targetFramework="net45" />
+  <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Reduced the minimum autofac version to 3.5.2 which currently has 1.2 million downloads on nuget as opposed to the 20k of v4.0.0.
