### PR TITLE
Changes to support SpecFlow 2.2.0

### DIFF
--- a/src/SpecFlow.Autofac.SpecFlowPlugin/AutofacPlugin.cs
+++ b/src/SpecFlow.Autofac.SpecFlowPlugin/AutofacPlugin.cs
@@ -15,7 +15,7 @@ namespace SpecFlow.Autofac
         {
             runtimePluginEvents.CustomizeGlobalDependencies += (sender, args) =>
             {
-                args.ObjectContainer.RegisterTypeAs<AutofacBindingInstanceResolver, IBindingInstanceResolver>();
+                args.ObjectContainer.RegisterTypeAs<AutofacTestObjectResolver, ITestObjectResolver>();
                 args.ObjectContainer.RegisterTypeAs<ContainerBuilderFinder, IContainerBuilderFinder>();
             };
 

--- a/src/SpecFlow.Autofac.SpecFlowPlugin/AutofacTestObjectResolver.cs
+++ b/src/SpecFlow.Autofac.SpecFlowPlugin/AutofacTestObjectResolver.cs
@@ -6,7 +6,7 @@ using TechTalk.SpecFlow.Infrastructure;
 
 namespace SpecFlow.Autofac
 {
-    public class AutofacBindingInstanceResolver : IBindingInstanceResolver
+    public class AutofacTestObjectResolver : ITestObjectResolver
     {
         public object ResolveBindingInstance(Type bindingType, IObjectContainer scenarioContainer)
         {

--- a/src/SpecFlow.Autofac.SpecFlowPlugin/SpecFlow.Autofac.SpecFlowPlugin.csproj
+++ b/src/SpecFlow.Autofac.SpecFlowPlugin/SpecFlow.Autofac.SpecFlowPlugin.csproj
@@ -34,6 +34,10 @@
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -42,14 +46,14 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="TechTalk.SpecFlow, Version=2.1.0.0, Culture=neutral, PublicKeyToken=0778194805d6db41, processorArchitecture=MSIL">
-      <HintPath>..\packages\SpecFlow.2.1.0\lib\net45\TechTalk.SpecFlow.dll</HintPath>
+    <Reference Include="TechTalk.SpecFlow, Version=2.2.0.0, Culture=neutral, PublicKeyToken=0778194805d6db41, processorArchitecture=MSIL">
+      <HintPath>..\packages\SpecFlow.2.2.0\lib\net45\TechTalk.SpecFlow.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AutofacBindingInstanceResolver.cs" />
     <Compile Include="AutofacPlugin.cs" />
+    <Compile Include="AutofacTestObjectResolver.cs" />
     <Compile Include="BindingRegistryExtensions.cs" />
     <Compile Include="ContainerBuilderFinder.cs" />
     <Compile Include="IContainerBuilderFinder.cs" />

--- a/src/SpecFlow.Autofac.SpecFlowPlugin/packages.config
+++ b/src/SpecFlow.Autofac.SpecFlowPlugin/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
-  <package id="SpecFlow" version="2.1.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="SpecFlow" version="2.2.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
In https://github.com/techtalk/SpecFlow/commit/7098c83986a11702fad2db90928043057feda037, ` IBindingInstanceResolver` was renamed to `ITestObjectResolver`. Unfortunately this is a breaking change made on a minor version and has broken SpecFlow.Autofac. 

It was simply a rename and all the contracts are the same, so all I've done is update the package and reflect the renaming. Note that SpecFlow 2.2.0 now has a Newtonsoft.Json dependency.