### PR TITLE
Updated Specflow to version 3, Autofac to version 4.9.1

### DIFF
--- a/src/SpecFlow.Autofac.SpecFlowPlugin/App.config
+++ b/src/SpecFlow.Autofac.SpecFlowPlugin/App.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration />

--- a/src/SpecFlow.Autofac.SpecFlowPlugin/AutofacPlugin.cs
+++ b/src/SpecFlow.Autofac.SpecFlowPlugin/AutofacPlugin.cs
@@ -12,12 +12,13 @@ namespace SpecFlow.Autofac
     using BoDi;
 
     using TechTalk.SpecFlow;
+    using TechTalk.SpecFlow.UnitTestProvider;
 
     public class AutofacPlugin : IRuntimePlugin
     {
         private static Object _registrationLock = new Object();
 
-        public void Initialize(RuntimePluginEvents runtimePluginEvents, RuntimePluginParameters runtimePluginParameters)
+        public void Initialize(RuntimePluginEvents runtimePluginEvents, RuntimePluginParameters runtimePluginParameters, UnitTestProviderConfiguration unitTestProviderConfiguration)
         {
             runtimePluginEvents.CustomizeGlobalDependencies += (sender, args) =>
             {

--- a/src/SpecFlow.Autofac.SpecFlowPlugin/SpecFlow.Autofac.SpecFlowPlugin.csproj
+++ b/src/SpecFlow.Autofac.SpecFlowPlugin/SpecFlow.Autofac.SpecFlowPlugin.csproj
@@ -30,24 +30,37 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Autofac, Version=4.9.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.9.1\lib\net45\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="BoDi, Version=1.4.1.0, Culture=neutral, PublicKeyToken=ff7cd5ea2744b496, processorArchitecture=MSIL">
+      <HintPath>..\packages\BoDi.1.4.1\lib\net45\BoDi.dll</HintPath>
+    </Reference>
+    <Reference Include="Gherkin, Version=6.0.0.0, Culture=neutral, PublicKeyToken=86496cfa5b4a5851, processorArchitecture=MSIL">
+      <HintPath>..\packages\Gherkin.6.0.0\lib\net45\Gherkin.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.4.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="TechTalk.SpecFlow, Version=2.2.0.0, Culture=neutral, PublicKeyToken=0778194805d6db41, processorArchitecture=MSIL">
-      <HintPath>..\packages\SpecFlow.2.2.1\lib\net45\TechTalk.SpecFlow.dll</HintPath>
+    <Reference Include="TechTalk.SpecFlow, Version=3.0.0.0, Culture=neutral, PublicKeyToken=0778194805d6db41, processorArchitecture=MSIL">
+      <HintPath>..\packages\SpecFlow.3.0.188\lib\net45\TechTalk.SpecFlow.dll</HintPath>
+    </Reference>
+    <Reference Include="Utf8Json, Version=1.3.7.0, Culture=neutral, PublicKeyToken=8a73d3ba7e392e27, processorArchitecture=MSIL">
+      <HintPath>..\packages\Utf8Json.1.3.7\lib\net45\Utf8Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SpecFlow.Autofac.SpecFlowPlugin/packages.config
+++ b/src/SpecFlow.Autofac.SpecFlowPlugin/packages.config
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="SpecFlow" version="2.2.1" targetFramework="net45" />
+  <package id="Autofac" version="4.9.1" targetFramework="net45" />
+  <package id="BoDi" version="1.4.1" targetFramework="net45" />
+  <package id="Gherkin" version="6.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net45" />
+  <package id="SpecFlow" version="3.0.188" targetFramework="net45" />
+  <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
+  <package id="Utf8Json" version="1.3.7" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR updates the Specflow version to 3 and Autofac to 4.9.1. I've ran a couple of smoke-style tests which seem to be fine, but some more extensive testing might be a good idea. 