### PR TITLE
Use modern Autofac syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ A typical dependency builder method probably looks like this:
       var builder = Dependencies.CreateContainerBuilder();
 
       //TODO: add customizations, stubs required for testing
-
-      builder.RegisterTypes(typeof(TestDependencies).Assembly.GetTypes().Where(t => Attribute.IsDefined(t, typeof(BindingAttribute))).ToArray()).SingleInstance();
+      builder.
+        RegisterAssemblyTypes(Assembly.GetAssembly(typeof(TestDependencies))).
+        Where(t => Attribute.IsDefined(t, typeof(BindingAttribute))).
+        SingleInstance();
       
       return builder;
     }


### PR DESCRIPTION
As latest versions of Specflow.Autofac use Autofac 4.0.0, I propose updating syntax for `[Binding]` classes registration.

I understand that Specflow.Autofac code is currently maintained as a part of the Specflow, but searches for documentation usually point to this repository, or @gasparnagy 's blog post. 